### PR TITLE
use time() instead of mktime()

### DIFF
--- a/FeedCache.php
+++ b/FeedCache.php
@@ -72,7 +72,7 @@ class FeedCache {
   private function check_expired() {
     if($this->is_local === true) {
       $valid_until = filemtime($this->local) + $this->valid_for;
-      return $valid_until < mktime();
+      return $valid_until < time();
     }
     return true;
   }


### PR DESCRIPTION
As of PHP 5.1, when called with no arguments, `mktime()` throws an `E_STRICT` notice: use the `time()` function instead.
