### PR TITLE
Pass only remote filename

### DIFF
--- a/FeedCache.php
+++ b/FeedCache.php
@@ -13,8 +13,8 @@ class FeedCache {
   private $is_local;
   private $data = false;
 
-  public function __construct($local, $remote, $valid_for=3600) {
-    $this->local = ROOT.'cache/'.$local;
+  public function __construct($remote, $valid_for=3600) {
+    $this->local = ROOT . 'cache/' . hash('md4', $remote);
     $this->remote = $remote;
     $this->valid_for = $valid_for;
     $this->is_local = $this->check_local();

--- a/README.md
+++ b/README.md
@@ -9,10 +9,18 @@ Include FeedCache.php in your script
 Then simply pass in the local file-name (that you want to save it as) and the remote feed:
 
 ```php
-  $feed_cache = new FeedCache('local_file.xml', 'http://example.com/feed.xml');
+  $feed_cache = new FeedCache('http://example.com/feed.xml');
   $data = simplexml_load_string($feed_cache->get_data());
 ```
+
 You will also need to make sure you have a writable folder called "cache" in the root of your site.
+
+The local filename is hashed string, which represents remote URI, you can specify used algorithm from __construct() method inside FeedCache class.
+
+```php
+	/* http://php.net/manual/en/function.hash.php */
+    $this->local = ROOT . 'cache/' . hash('md4', $remote); 
+```
 
 Changelog
 ---------

--- a/README.md
+++ b/README.md
@@ -24,7 +24,8 @@ The local filename is hashed string, which represents remote URI, you can specif
 
 Changelog
 ---------
-
+* v1.1 (2013-04-26)
+** UPDATE: Pass onle name of remote feed, the script will store hash of it's name as filename of local cache file.
 * v1 (2012-04-26)
 ** ADD: Initial commit
 


### PR DESCRIPTION
If we are using this piece of code to cache more than one feed, it would be better to pass only URL of remote file. Works fine for single feed as well.
